### PR TITLE
Allow to define supported architectures in apt sources

### DIFF
--- a/tasks/repositories.yml
+++ b/tasks/repositories.yml
@@ -26,7 +26,7 @@
     manala_apt_repositories_exclusive
     and (
       item not in __manala_apt_repositories|map(attribute='source')
-        |map('regex_replace', '^deb https?:\\/\\/([^ ]+)[ ].*$', '\\1')
+        |map('regex_replace', '^deb (\\[.+\\] )?https?:\\/\\/([^ ]+)[ ].*$', '\\2')
         |map('replace', '.', ' ')
         |map('replace', '/', ' ')
         |map('trim')

--- a/tasks/vars.yml
+++ b/tasks/vars.yml
@@ -23,7 +23,7 @@
                 ].pin|default(
                   'origin ' ~ manala_apt_repositories_patterns[
                     (item.split('@')[1]|default(item)).split(':')[0]
-                  ].source|regex_replace('deb https?:\\/\\/([^\\/ ]+)[\\/ ].*$', '\\1')
+                  ].source|regex_replace('deb (\\[.+\\] )?https?:\\/\\/([^\\/ ]+)[\\/ ].*$', '\\2')
                 )
               ),
               'priority': (item.split(':')[1]|default(900))|int

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -128,7 +128,7 @@ manala_apt_repositories_patterns:
     source: deb https://apt.dockerproject.org/repo debian-{{ ansible_distribution_release }} main
     key: docker
   manala:
-    source: deb http://debian.manala.io {{ ansible_distribution_release }} main
+    source: deb [arch=amd64] http://debian.manala.io {{ ansible_distribution_release }} main
     key: manala
   newrelic:
     source: deb http://apt.newrelic.com/debian/ newrelic non-free


### PR DESCRIPTION
Should fix `apt-get update` failure when `manala` repository is enable on host with architecture != amd64.
