### PR TITLE
Introduce shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ None
     manala_apt_repositories:
       - contrib
     manala_apt_preferences:
-      - git@debian_backports
+      - git@backports
       - dotdeb:100
       - php@dotdeb_php56:300
       - nginx@nginx
@@ -87,13 +87,13 @@ manala_apt_sources_list:
 Or use predefined templates
 
 ```yaml
-manala_apt_sources_list_template: sources_list/debian.j2
+manala_apt_sources_list_template: sources_list/default.j2
 ```
 
 Or combine both
 
 ```yaml
-manala_apt_sources_list_template: sources_list/debian_src.j2
+manala_apt_sources_list_template: sources_list/default_src.j2
 manala_apt_sources_list:
   - deb-src: http://httpredir.debian.org/debian wheezy main
   - deb-src http://httpredir.debian.org/debian wheezy contrib
@@ -105,15 +105,19 @@ Concise, pattern based
 
 ```yaml
 manala_apt_repositories:
-  - debian_security
-  - debian_security_src
-  - debian_updates
-  - debian_updates_src
-  - debian_backports
-  - ubuntu_security
-  - ubuntu_updates
-  - ubuntu_partner
-  - ubuntu_backports
+  - security # Distribution auto-detection
+  - updates # Distribution auto-detection
+  - partner # Distribution auto-detection
+  - backports # Distribution auto-detection
+  - debian_security # Deprecated, use 'security'
+  - debian_security_src # Deprecated, use 'security_src'
+  - debian_updates # Deprecated, use 'updates'
+  - debian_updates_src # Deprecated, use 'updates_src'
+  - debian_backports # Deprecated, use 'backports'
+  - ubuntu_security # Deprecated, use 'security'
+  - ubuntu_updates # Deprecated, use 'updates'
+  - ubuntu_partner # Deprecated, use 'partner'
+  - ubuntu_backports # Deprecated, use 'backports'
   - dotdeb
   - dotdeb_php54
   - dotdeb_php55
@@ -140,15 +144,16 @@ manala_apt_repositories:
   - elasticsearch_1_7
   - ppa_ansible
   - blackfire
-  - sury_php_debian
-  - sury_php_ubuntu
+  - sury_php # Distribution auto-detection
+  - sury_php_debian # Deprecated, use 'sury_php'
+  - sury_php_ubuntu # Deprecated, use 'sury_php'
 ```
 
 Verbose, pattern based
 
 ```yaml
 manala_apt_repositories:
-  - pattern: debian_backports
+  - pattern: backports
     state:   absent
 ```
 
@@ -180,11 +185,11 @@ Note that referenced repositories will automatically be include as present using
 
 ```yaml
 manala_apt_preferences:
-  - git@debian_backports         # "git*"" from debian backports repository, high priority
-  - dotdeb:100                   # "*" from dotdeb repository, low priority
-  - php@dotdeb                   # "php*" from dotdeb repository, high priority
-  - redis@dotdeb                 # "redis*" from dotdeb repository, high priority
-  - libssl1.0.0@debian_backports # "libssl1.0.0" from debian backports repository, high priority (in this case "libssl1.0.0" is not a pre-defined preference pattern; as a matter of consequence the package is directly used)
+  - git@backports         # "git*"" from debian|ubuntu backports repository, high priority
+  - dotdeb:100            # "*" from dotdeb repository, low priority
+  - php@dotdeb            # "php*" from dotdeb repository, high priority
+  - redis@dotdeb          # "redis*" from dotdeb repository, high priority
+  - libssl1.0.0@backports # "libssl1.0.0" from debian|ubuntu backports repository, high priority (in this case "libssl1.0.0" is not a pre-defined preference pattern; as a matter of consequence the package is directly used)
 ```
 
 Verbose

--- a/templates/sources_list/debian.j2
+++ b/templates/sources_list/debian.j2
@@ -1,6 +1,3 @@
-{%- import '_macros.j2' as macros with context -%}
+{#- Deprecated -#}
 
-{% set config = manala_apt_sources_list -%}
-
-deb http://httpredir.debian.org/debian {{ ansible_distribution_release }} {{ manala_apt_components|join(' ') }}
-{{ macros.config(config) }}
+{% include 'debian/default.j2' %}

--- a/templates/sources_list/debian/default.j2
+++ b/templates/sources_list/debian/default.j2
@@ -1,0 +1,6 @@
+{%- import '_macros.j2' as macros with context -%}
+
+{% set config = manala_apt_sources_list -%}
+
+deb http://httpredir.debian.org/debian {{ ansible_distribution_release }} {{ manala_apt_components|join(' ') }}
+{{ macros.config(config) }}

--- a/templates/sources_list/debian/default_src.j2
+++ b/templates/sources_list/debian/default_src.j2
@@ -1,0 +1,7 @@
+{%- import '_macros.j2' as macros with context -%}
+
+{% set config = manala_apt_sources_list -%}
+
+deb http://httpredir.debian.org/debian {{ ansible_distribution_release }} {{ manala_apt_components|join(' ') }}
+deb-src http://httpredir.debian.org/debian {{ ansible_distribution_release }} {{ manala_apt_components|join(' ') }}
+{{ macros.config(config) }}

--- a/templates/sources_list/debian/security_updates.j2
+++ b/templates/sources_list/debian/security_updates.j2
@@ -1,0 +1,8 @@
+{%- import '_macros.j2' as macros with context -%}
+
+{% set config = manala_apt_sources_list -%}
+
+deb http://httpredir.debian.org/debian {{ ansible_distribution_release }} {{ manala_apt_components|join(' ') }}
+deb http://security.debian.org/ {{ ansible_distribution_release }}/updates {{ manala_apt_components|join(' ') }}
+deb http://httpredir.debian.org/debian {{ ansible_distribution_release }}-updates {{ manala_apt_components|join(' ') }}
+{{ macros.config(config) }}

--- a/templates/sources_list/debian/security_updates_ovh.j2
+++ b/templates/sources_list/debian/security_updates_ovh.j2
@@ -1,0 +1,8 @@
+{%- import '_macros.j2' as macros with context -%}
+
+{% set config = manala_apt_sources_list -%}
+
+deb http://debian.mirrors.ovh.net/debian/ {{ ansible_distribution_release }} {{ manala_apt_components|join(' ') }}
+deb http://security.debian.org/ {{ ansible_distribution_release }}/updates {{ manala_apt_components|join(' ') }}
+deb http://debian.mirrors.ovh.net/debian/ {{ ansible_distribution_release }}-updates {{ manala_apt_components|join(' ') }}
+{{ macros.config(config) }}

--- a/templates/sources_list/debian_security_updates.j2
+++ b/templates/sources_list/debian_security_updates.j2
@@ -1,8 +1,3 @@
-{%- import '_macros.j2' as macros with context -%}
+{#- Deprecated -#}
 
-{% set config = manala_apt_sources_list -%}
-
-deb http://httpredir.debian.org/debian {{ ansible_distribution_release }} {{ manala_apt_components|join(' ') }}
-deb http://security.debian.org/ {{ ansible_distribution_release }}/updates {{ manala_apt_components|join(' ') }}
-deb http://httpredir.debian.org/debian {{ ansible_distribution_release }}-updates {{ manala_apt_components|join(' ') }}
-{{ macros.config(config) }}
+{% include 'debian/security_updates.j2' %}

--- a/templates/sources_list/debian_security_updates_ovh.j2
+++ b/templates/sources_list/debian_security_updates_ovh.j2
@@ -1,8 +1,3 @@
-{%- import '_macros.j2' as macros with context -%}
+{#- Deprecated -#}
 
-{% set config = manala_apt_sources_list -%}
-
-deb http://debian.mirrors.ovh.net/debian/ {{ ansible_distribution_release }} {{ manala_apt_components|join(' ') }}
-deb http://security.debian.org/ {{ ansible_distribution_release }}/updates {{ manala_apt_components|join(' ') }}
-deb http://debian.mirrors.ovh.net/debian/ {{ ansible_distribution_release }}-updates {{ manala_apt_components|join(' ') }}
-{{ macros.config(config) }}
+{% include 'debian/security_updates_ovh.j2' %}

--- a/templates/sources_list/debian_src.j2
+++ b/templates/sources_list/debian_src.j2
@@ -1,7 +1,3 @@
-{%- import '_macros.j2' as macros with context -%}
+{#- Deprecated -#}
 
-{% set config = manala_apt_sources_list -%}
-
-deb http://httpredir.debian.org/debian {{ ansible_distribution_release }} {{ manala_apt_components|join(' ') }}
-deb-src http://httpredir.debian.org/debian {{ ansible_distribution_release }} {{ manala_apt_components|join(' ') }}
-{{ macros.config(config) }}
+{% include 'debian/default_src.j2' %}

--- a/templates/sources_list/default.j2
+++ b/templates/sources_list/default.j2
@@ -1,0 +1,1 @@
+{% include ansible_distribution|lower ~ '/default.j2' %}

--- a/templates/sources_list/default_src.j2
+++ b/templates/sources_list/default_src.j2
@@ -1,0 +1,1 @@
+{% include ansible_distribution|lower ~ '/default_src.j2' %}

--- a/templates/sources_list/security_updates.j2
+++ b/templates/sources_list/security_updates.j2
@@ -1,0 +1,1 @@
+{% include ansible_distribution|lower ~ '/security_updates.j2' %}

--- a/templates/sources_list/security_updates_ovh.j2
+++ b/templates/sources_list/security_updates_ovh.j2
@@ -1,0 +1,1 @@
+{% include ansible_distribution|lower ~ '/security_updates_ovh.j2' %}

--- a/templates/sources_list/ubuntu.j2
+++ b/templates/sources_list/ubuntu.j2
@@ -1,6 +1,3 @@
-{%- import '_macros.j2' as macros with context -%}
+{#- Deprecated -#}
 
-{% set config = manala_apt_sources_list -%}
-
-deb http://archive.ubuntu.com/ubuntu {{ ansible_distribution_release }} {{ manala_apt_components|join(' ') }}
-{{ macros.config(config) }}
+{% include 'ubuntu/default.j2' %}

--- a/templates/sources_list/ubuntu/default.j2
+++ b/templates/sources_list/ubuntu/default.j2
@@ -1,0 +1,6 @@
+{%- import '_macros.j2' as macros with context -%}
+
+{% set config = manala_apt_sources_list -%}
+
+deb http://archive.ubuntu.com/ubuntu {{ ansible_distribution_release }} {{ manala_apt_components|join(' ') }}
+{{ macros.config(config) }}

--- a/tests/020_sources_list.yml
+++ b/tests/020_sources_list.yml
@@ -5,7 +5,7 @@
   vars:
     manala_apt_components:
       - main
-    manala_apt_sources_list_template: sources_list/debian_security_updates.j2
+    manala_apt_sources_list_template: sources_list/security_updates.j2
   pre_tasks:
     - copy:
         dest: /etc/apt/sources.list

--- a/tests/030_preferences.yml
+++ b/tests/030_preferences.yml
@@ -5,8 +5,8 @@
   vars:
     manala_apt_preferences_exclusive: true
     manala_apt_preferences:
-      - git@debian_backports
-      - libssl1.0.0@debian_backports
+      - git@backports
+      - libssl1.0.0@backports
       - php@dotdeb:300
       - dotdeb:100
       - dotdeb:200

--- a/tests/040_keys.yml
+++ b/tests/040_keys.yml
@@ -5,8 +5,8 @@
   vars:
     manala_apt_preferences_exclusive: true
     manala_apt_preferences:
-      - git@debian_backports
-      - libssl1.0.0@debian_backports
+      - git@backports
+      - libssl1.0.0@backports
       - php@dotdeb:300
       - dotdeb:100
       - dotdeb:200
@@ -16,7 +16,7 @@
         file:     foo_bar
     manala_apt_repositories_exclusive: true
     manala_apt_repositories:
-      - debian_security
+      - security
       - nginx
       - nginx
       - gitlab-ce

--- a/tests/050_repositories.yml
+++ b/tests/050_repositories.yml
@@ -5,8 +5,8 @@
   vars:
     manala_apt_preferences_exclusive: true
     manala_apt_preferences:
-      - git@debian_backports
-      - libssl1.0.0@debian_backports
+      - git@backports
+      - libssl1.0.0@backports
       - php@dotdeb:300
       - dotdeb:100
       - dotdeb:200
@@ -16,7 +16,7 @@
         file:     foo_bar
     manala_apt_repositories_exclusive: true
     manala_apt_repositories:
-      - debian_security
+      - security
       - nginx
       - nginx
       - gitlab-ce

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,23 +2,88 @@
 
 # Repositories
 manala_apt_repositories_patterns:
+  security: "{{
+    {
+      'debian': {
+        'source': 'deb http://security.debian.org/ ' ~ ansible_distribution_release ~ '/updates ' ~ manala_apt_components|join(' ')
+      },
+      'ubuntu': {
+        'source': 'deb http://security.ubuntu.com/ubuntu ' ~ ansible_distribution_release ~ '-security ' ~ manala_apt_components|join(' ')
+      }
+    }[ansible_distribution|lower]
+  }}"
+  security_src: "{{
+    {
+      'debian': {
+        'source': 'deb-src http://security.debian.org/ ' ~ ansible_distribution_release ~ '/updates ' ~ manala_apt_components|join(' ')
+      },
+      'ubuntu': None
+    }[ansible_distribution|lower]
+  }}"
+  updates: "{{
+    {
+      'debian': {
+        'source': 'deb http://httpredir.debian.org/debian ' ~ ansible_distribution_release ~ '-updates ' ~ manala_apt_components|join(' ')
+      },
+      'ubuntu': {
+        'source': 'deb http://archive.ubuntu.com/ubuntu ' ~ ansible_distribution_release ~ '-updates ' ~ manala_apt_components|join(' ')
+      }
+    }[ansible_distribution|lower]
+  }}"
+  updates_src: "{{
+    {
+      'debian': {
+        'source': 'deb-src http://httpredir.debian.org/debian ' ~ ansible_distribution_release ~ '-updates ' ~ manala_apt_components|join(' ')
+      },
+      'ubuntu': None
+    }[ansible_distribution|lower]
+  }}"
+  partner: "{{
+    {
+      'debian': None,
+      'ubuntu': {
+        'source': 'deb http://archive.canonical.com/ubuntu ' ~ ansible_distribution_release ~ ' partner'
+      }
+    }[ansible_distribution|lower]
+  }}"
+  backports: "{{
+    {
+      'debian': {
+        'source': 'deb http://httpredir.debian.org/debian ' ~ ansible_distribution_release ~ '-backports ' ~ manala_apt_components|join(' '),
+        'pin':    'release a=' ~ ansible_distribution_release ~ '-backports'
+      },
+      'ubuntu': {
+        'source': 'deb http://archive.ubuntu.com/ubuntu ' ~ ansible_distribution_release ~ '-backports ' ~ manala_apt_components|join(' '),
+        'pin':    'release a=' ~ ansible_distribution_release ~ '-backports'
+      }
+    }[ansible_distribution|lower]
+  }}"
+  # Deprecated
   debian_security:
     source: deb http://security.debian.org/ {{ ansible_distribution_release }}/updates {{ manala_apt_components|join(' ') }}
+  # Deprecated
   debian_security_src:
     source: deb-src http://security.debian.org/ {{ ansible_distribution_release }}/updates {{ manala_apt_components|join(' ') }}
+  # Deprecated
   debian_updates:
     source: deb http://httpredir.debian.org/debian {{ ansible_distribution_release }}-updates {{ manala_apt_components|join(' ') }}
+  # Deprecated
   debian_updates_src:
     source: deb-src http://httpredir.debian.org/debian {{ ansible_distribution_release }}-updates {{ manala_apt_components|join(' ') }}
+  # Deprecated
   debian_backports:
     source: deb http://httpredir.debian.org/debian {{ ansible_distribution_release }}-backports {{ manala_apt_components|join(' ') }}
     pin: release a={{ ansible_distribution_release }}-backports
+  # Deprecated
   ubuntu_security:
     source: deb http://security.ubuntu.com/ubuntu {{ ansible_distribution_release }}-security {{ manala_apt_components|join(' ') }}
+  # Deprecated
   ubuntu_updates:
     source: deb http://archive.ubuntu.com/ubuntu {{ ansible_distribution_release }}-updates {{ manala_apt_components|join(' ') }}
+  # Deprecated
   ubuntu_partner:
     source: deb http://archive.canonical.com/ubuntu {{ ansible_distribution_release }} partner
+  # Deprecated
   ubuntu_backports:
     source: deb http://archive.ubuntu.com/ubuntu {{ ansible_distribution_release }}-backports {{ manala_apt_components|join(' ') }}
     pin: release a={{ ansible_distribution_release }}-backports
@@ -116,6 +181,15 @@ manala_apt_repositories_patterns:
   elasticsearch_2:
     source: deb http://packages.elastic.co/elasticsearch/2.x/debian stable main
     key: elasticsearch
+  ansible: "{{
+    {
+      'debian': None,
+      'ubuntu': {
+        'source': 'ppa:ansible/ansible'
+      }
+    }[ansible_distribution|lower]
+  }}"
+  # Deprecated
   ppa_ansible:
     source: ppa:ansible/ansible
   blackfire:
@@ -142,9 +216,23 @@ manala_apt_repositories_patterns:
   yarn:
     source: deb http://dl.yarnpkg.com/debian/ stable main
     key: yarn
+  sury_php: "{{
+    {
+      'debian': {
+        'source': 'deb https://packages.sury.org/php/ ' ~ ansible_distribution_release ~ ' main',
+        'key':    'sury_php'
+      },
+      'ubuntu': {
+        'source': 'ppa:ondrej/php',
+        'key':    'sury_php'
+      }
+    }[ansible_distribution|lower]
+  }}"
+  # Deprecated
   sury_php_debian:
     source: deb https://packages.sury.org/php/ {{ ansible_distribution_release }} main
     key: sury_php_debian
+  # Deprecated
   sury_php_ubuntu:
     source: ppa:ondrej/php
     key: sury_php_ubuntu
@@ -228,9 +316,23 @@ manala_apt_keys_patterns:
   yarn:
     url: http://dl.yarnpkg.com/debian/pubkey.gpg
     id: 86E50310
+  sury_php: "{{
+    {
+      'debian': {
+        'url': 'https://packages.sury.org/php/apt.gpg',
+        'id':  '4A7A714D'
+      },
+      'ubuntu': {
+        'keyserver': 'hkp://keyserver.ubuntu.com:80',
+        'id':        'E5267A6C'
+      }
+    }[ansible_distribution|lower]
+  }}"
+  # Deprecated
   sury_php_debian:
     url: https://packages.sury.org/php/apt.gpg
     id: 4A7A714D
+  # Deprecated
   sury_php_ubuntu:
     keyserver: hkp://keyserver.ubuntu.com:80
     id: E5267A6C


### PR DESCRIPTION
Fully bc, with following deprecations:

* Repositories patterns
  * debian_security -> security
  * debian_security_src -> security_src
  * debian_updates -> updates
  * debian_updates_src -> security_src
  * debian_backports -> backports
  * ubuntu_security -> security
  * ubuntu_updates ->updates
  * ubuntu_partner -> partner
  * ubuntu_backports -> backports
  * sury_php_debian -> sury_php
  * sury_php_ubuntu -> sury_php
  * ppa_ansible -> ansible

*  Keys patterns
  * sury_php_debian -> sury_php
  * sury_php_ubuntu -> sury_php

* Sources list templates
  * sources_list/debian.j2 -> sources_list/default.j2
  * sources_list/debian_src.j2 -> sources_list/default_src.j2
  * sources_list/debian_security_updates.j2 -> sources_list/security_updates.j2
  * sources_list/debian_security_updates_ovh.j2 -> sources_list/security_updates_ovh.j2
  * sources_list/ubuntu.j2 -> sources_list/default.j2