### PR TITLE
fix with ansible linter

### DIFF
--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -4,6 +4,8 @@
   shell: |
     set -o pipefail
     dpkg --get-selections {{ item }} | cut -f 2- | tr -d '\t'
+  args:
+    executable: /bin/bash
   with_items: "{{ manala_apt_update_holds }}"
   when:
     - manala_apt_update_holds|length
@@ -13,6 +15,8 @@
   shell:
     set -o pipefail
     echo '{{ item.0 }} hold' | dpkg --set-selections
+  args:
+    executable: /bin/bash
   when:
     - ( item.1 | length > 0 )
     - ( item.1 != 'hold' )
@@ -29,6 +33,8 @@
   shell: |
     set -o pipefail
     echo '{{ item.0 }} {{ item.1 }}' | dpkg --set-selections
+  args:
+    executable: /bin/bash
   when:
     - ( item.1 | length > 0 )
   with_together:

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -1,14 +1,21 @@
 ---
 
 - name: update > Backup package marks
-  shell: "dpkg --get-selections {{ item }} | cut -f 2- | tr -d '\t'"
+  shell: |
+    set -o pipefail
+    dpkg --get-selections {{ item }} | cut -f 2- | tr -d '\t'
   with_items: "{{ manala_apt_update_holds }}"
-  when: manala_apt_update_holds|length
+  when:
+    - manala_apt_update_holds|length
   register: __manala_apt_update_marks_results
 
 - name: update > Hold packages
-  shell: "echo '{{ item.0 }} hold' | dpkg --set-selections"
-  when: item.1 != '' and item.1 != 'hold'
+  shell:
+    set -o pipefail
+    echo '{{ item.0 }} hold' | dpkg --set-selections
+  when:
+    - ( item.1 | length > 0 )
+    - ( item.1 != 'hold' )
   with_together:
     - "{{ manala_apt_update_holds }}"
     - "{{ __manala_apt_update_marks_results.results|map(attribute='stdout')|list }}"
@@ -19,8 +26,11 @@
     update_cache: true
 
 - name: update > Restore package marks
-  shell: "echo '{{ item.0 }} {{ item.1 }}' | dpkg --set-selections"
-  when: item.1 != ''
+  shell: |
+    set -o pipefail
+    echo '{{ item.0 }} {{ item.1 }}' | dpkg --set-selections
+  when:
+    - ( item.1 | length > 0 )
   with_together:
     - "{{ manala_apt_update_holds }}"
     - "{{ __manala_apt_update_marks_results.results|map(attribute='stdout')|list }}"


### PR DESCRIPTION
Fix according to ansible-galaxy import logs:
```
[306] Shells that use pipes should set the pipefail option
/tmp/1/ansible-role-apt/tasks/update.yml:3
Task/Handler: update > Backup package marks

[306] Shells that use pipes should set the pipefail option
/tmp/1/ansible-role-apt/tasks/update.yml:9
Task/Handler: update > Hold packages

[602] Don't compare to empty string
/tmp/1/ansible-role-apt/tasks/update.yml:11
  when: item.1 != '' and item.1 != 'hold'

[306] Shells that use pipes should set the pipefail option
/tmp/1/ansible-role-apt/tasks/update.yml:21
Task/Handler: update > Restore package marks

[602] Don't compare to empty string
/tmp/1/ansible-role-apt/tasks/update.yml:23
  when: item.1 != ''
```